### PR TITLE
readme: pipe stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ var client = foxtrot.connect({
   address: new Buffer(server, 'hex')
 }, function() {
   console.log('connected to server!');
-  process.stdout.pipe(client);
+  process.stdin.pipe(client);
   client.pipe(process.stdout);
 });
 ```

--- a/examples/chat
+++ b/examples/chat
@@ -49,9 +49,9 @@ var client = foxtrot.connect({address: new Buffer(program.server, 'hex')}, funct
   console.log('>>> connected to chat server');
   connected = true;
   client.write(program.nick);
-  process.stdout.pipe(client);
+  process.stdin.pipe(client);
   client.pipe(process.stdout);
-}); 
+});
 client.on('error', function(err) {
   console.error(err);
   foxtrot.stop();
@@ -60,4 +60,3 @@ client.on('close', function() {
   if(connected) console.log('>>> lost connection to chat server');
   foxtrot.stop();
 });
-

--- a/examples/chatd
+++ b/examples/chatd
@@ -76,7 +76,7 @@ if (program.key) {
   identity.regenerateSync();
 }
 console.log('>>> chat server listening on '+identity.public.toString('hex'));
-process.stdout.pipe(localSocket);
+process.stdin.pipe(localSocket);
 var server = foxtrot.createServer({
   key: identity,
   advertise: false

--- a/examples/echo-client.js
+++ b/examples/echo-client.js
@@ -3,11 +3,11 @@
 var foxtrot = require('..');
 
 // replace with server foxtrot address
-var server = '02b536305eaaebccc3b77fc5a12acbaf827ac093924d3b9ecc7cf43bcedd946c9c'; 
+var server = '02b536305eaaebccc3b77fc5a12acbaf827ac093924d3b9ecc7cf43bcedd946c9c';
 var client = foxtrot.connect({
   address: new Buffer(server, 'hex')
 }, function() {
   console.log('connected to server!');
-  process.stdout.pipe(client);
+  process.stdin.pipe(client);
   client.pipe(process.stdout);
 });

--- a/examples/self-connect
+++ b/examples/self-connect
@@ -76,7 +76,7 @@ if (program.key) {
   identity.regenerateSync();
 }
 console.log('>>> chat server listening on ' + identity.public.toString('hex'));
-process.stdout.pipe(localSocket);
+process.stdin.pipe(localSocket);
 var server = foxtrot.createServer({
   key: identity,
 });


### PR DESCRIPTION
I think that the intention here was to pipe `stdin` to the client so that typing on the keyboard would send data to the server. Since `stdout` is write-only it dosen't make sense to pipe it anywhere.
