### PR TITLE
Code Coverage, Tests

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+service_name: travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+- '0.10'
+after_script: istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,2 @@
+- Pull Requests must pass all tests.
+- New features should ship with new tests.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 
 # Foxtrot
+[![Build Status](https://travis-ci.org/bitpay/foxtrot.svg)](https://travis-ci.org/bitpay/foxtrot)
+[![Coverage Status](https://coveralls.io/repos/bitpay/foxtrot/badge.png?branch=master)](https://coveralls.io/r/bitpay/foxtrot?branch=master)
+
 
 A simple and secure routing network based on bitcoin cryptography.
 Foxtrot enables easy p2p communications and has built-in mechanisms
@@ -49,4 +52,3 @@ For more advanced examples and configuration, see the examples folder
 **Code released under [the MIT license](https://github.com/bitpay/foxtrot/blob/master/LICENSE).**
 
 Copyright 2014 BitPay, Inc.
-

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A simple routing network.",
   "main": "index.js",
   "scripts": {
-    "test": "mocha test"
+    "test": "mocha",
+    "coverage": "istanbul cover _mocha"
   },
   "author": "Stephen Pair",
   "license": "MIT",
@@ -16,6 +17,8 @@
   },
   "devDependencies": {
     "async": "^0.9.0",
-    "chai": "^1.9.1"
+    "chai": "^1.9.1",
+    "istanbul": "^0.3.2",
+    "mocha": "^2.0.1"
   }
 }


### PR DESCRIPTION
This implements Istanbul for code coverage, via `npm run coverage`.  Additionally, I've added support for both Travis and Coveralls, which will automatically run the tests and measure their code coverage, to be displayed at the top of foxtrot's `README.md.`
