### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ var client = foxtrot.connect({
 
 For more advanced examples and configuration, see the examples folder
 
-#License
+# License
 
 **Code released under [the MIT license](https://github.com/bitpay/foxtrot/blob/master/LICENSE).**
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
